### PR TITLE
Fix ChangeNamePretendsToCallServerButOurTestRunsFast

### DIFF
--- a/src/complete/ex3-reactivecommand-part2/Ex3.Tests/Ex3.Tests.csproj
+++ b/src/complete/ex3-reactivecommand-part2/Ex3.Tests/Ex3.Tests.csproj
@@ -47,11 +47,24 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Reactive.Interfaces">
+    <Reference Include="System.Reactive.Core">
+      <HintPath>..\packages\Rx-Core.2.2.5\lib\net45\System.Reactive.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reactive.Interfaces, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Rx-Interfaces.2.2.5\lib\net45\System.Reactive.Interfaces.dll</HintPath>
     </Reference>
     <Reference Include="System.Reactive.Linq">
       <HintPath>..\packages\Rx-Linq.2.2.5\lib\net45\System.Reactive.Linq.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reactive.PlatformServices">
+      <HintPath>..\packages\Rx-PlatformServices.2.2.5\lib\net45\System.Reactive.PlatformServices.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reactive.Windows.Threading">
+      <HintPath>..\packages\Rx-XAML.2.2.5\lib\net45\System.Reactive.Windows.Threading.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="WindowsBase" />
   </ItemGroup>

--- a/src/complete/ex3-reactivecommand-part2/Ex3.Tests/PersonViewModelTests.cs
+++ b/src/complete/ex3-reactivecommand-part2/Ex3.Tests/PersonViewModelTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Reactive.Linq;
+﻿using System;
 using Microsoft.Reactive.Testing;
 using NUnit.Framework;
 using ReactiveUI.Testing;
@@ -11,12 +11,12 @@ namespace Ex3.Tests
         [Test]
         public void ChangeNamePretendsToCallServerButOurTestRunsFast()
         {
-            (new TestScheduler()).With(async sched =>
+            (new TestScheduler()).With(sched =>
             {
                 var sut = new PersonViewModel {FirstName = "Jane", LastName = "Appleseed"};
                 Assert.IsTrue(sut.ChangeName.CanExecute(null));
 
-                await sut.ChangeName.ExecuteAsync();
+                sut.ChangeName.ExecuteAsync().Subscribe();
 
                 sched.AdvanceByMs(1000);
                 Assert.AreEqual(null, sut.ServerResult);

--- a/src/complete/ex3-reactivecommand-part2/Ex3/PersonViewModel.cs
+++ b/src/complete/ex3-reactivecommand-part2/Ex3/PersonViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Reactive.Linq;
 using System.Threading.Tasks;
 using ReactiveUI;
 
@@ -8,8 +9,9 @@ namespace Ex3
     {
         private async Task<string> PretendToCallTheServer()
         {
-            await Task.Delay(2000);
-            return "Hello World";
+            return await Observable.Return("Hello World")
+                .Delay(TimeSpan.FromSeconds(2), RxApp.TaskpoolScheduler)
+                .FirstAsync();
         } 
 
         public PersonViewModel()

--- a/src/exercises/ex3-reactivecommand-part2/Ex3.Tests/PersonViewModelTests.cs
+++ b/src/exercises/ex3-reactivecommand-part2/Ex3.Tests/PersonViewModelTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Reactive.Linq;
+﻿using System;
 using Microsoft.Reactive.Testing;
 using NUnit.Framework;
 using ReactiveUI.Testing;
@@ -14,12 +14,12 @@ namespace Ex3.Tests
         [Test]
         public void ChangeNamePretendsToCallServerButOurTestRunsFast()
         {
-            (new TestScheduler()).With(async sched =>
+            (new TestScheduler()).With(sched =>
             {
                 var sut = new PersonViewModel {FirstName = "Jane", LastName = "Appleseed"};
                 Assert.IsTrue(sut.ChangeName.CanExecute(null));
 
-                await sut.ChangeName.ExecuteAsync();
+                sut.ChangeName.ExecuteAsync().Subscribe();
 
                 sched.AdvanceByMs(1000);
                 Assert.AreEqual(null, sut.ServerResult);

--- a/src/exercises/ex3-reactivecommand-part2/Ex3/PersonViewModel.cs
+++ b/src/exercises/ex3-reactivecommand-part2/Ex3/PersonViewModel.cs
@@ -9,8 +9,9 @@ namespace Ex3
     {
         private async Task<string> PretendToCallTheServer()
         {
-            await Task.Delay(2000);
-            return "Hello World";
+            return await Observable.Return("Hello World")
+                .Delay(TimeSpan.FromSeconds(2), RxApp.TaskpoolScheduler)
+                .FirstAsync();
         } 
 
         public PersonViewModel()


### PR DESCRIPTION
The unit test was running to completion before the async method passed to `Scheduler.With` had completed.

You can see this by placing a breakpoint on the last assert, and running the unit test with a debugger attached; the breakpoint will not be hit.

Notes:
- `ExecuteAsync` requires a subscription to run.
- `Scheduler.With` [requires the use](http://stackoverflow.com/a/16198967/1220238) of `RxApp.TaskpoolScheduler` or
  `RxApp.DeferredScheduler`.
- References were missing from the completed project.
